### PR TITLE
install sccache into vcpkg installation directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,10 @@ jobs:
       run: ./vcpkg install --clean-after-build --recurse ${{ env.VCPKG_PACKAGES }}
       working-directory: ${{ matrix.vcpkg_path }}
 
+    - name: Build cargo
+      run: cargo install --git https://github.com/mozilla/sccache.git
+           --root ${{ matrix.vcpkg_path }}/installed/${{ matrix.vcpkg_triplet }}/tools/sccache
+
     - name: Upload GitHub Actions artifacts of build logs
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
This will save time building sccache for the application CI jobs. Plus it will make it easy for developers to use sccache without needing to install a Rust toolchain. This should be usable for macOS as well.