### PR TITLE
Fix protobuf warning on MacOS

### DIFF
--- a/overlay/osx/protobuf/fix-default-proto-file-path.patch
+++ b/overlay/osx/protobuf/fix-default-proto-file-path.patch
@@ -1,0 +1,20 @@
+diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
+index f192ae6..22900ed 100644
+--- a/src/google/protobuf/compiler/command_line_interface.cc
++++ b/src/google/protobuf/compiler/command_line_interface.cc
+@@ -260,11 +260,15 @@ void AddDefaultProtoPaths(
+     return;
+   }
+   // Check if the upper level directory has an "include" subdirectory.
++  // change "'$/bin' is next to 'include'" assumption to "'$/bin/tools' is next to 'include'"
++  for (int i = 0; i < 2; i++)
++  {
+   pos = path.find_last_of("/\\");
+   if (pos == std::string::npos || pos == 0) {
+     return;
+   }
+   path = path.substr(0, pos);
++  }
+   if (IsInstalledProtoPath(path + "/include")) {
+     paths->push_back(
+         std::pair<std::string, std::string>("", path + "/include"));

--- a/overlay/osx/protobuf/fix-static-build.patch
+++ b/overlay/osx/protobuf/fix-static-build.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 4091bc8..9850018 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -31,7 +31,7 @@ endforeach()
+ if (protobuf_BUILD_PROTOC_BINARIES)
+   install(TARGETS protoc EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+-  if (UNIX AND NOT APPLE)
++  if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
+     set_property(TARGET protoc
+       PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+   elseif (APPLE)

--- a/overlay/osx/protobuf/port_def.patch
+++ b/overlay/osx/protobuf/port_def.patch
@@ -1,0 +1,14 @@
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index f7b64a080..3493d9082 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -564,7 +564,8 @@
+ 
+ // Our use of constinit does not yet work with GCC:
+ // https://github.com/protocolbuffers/protobuf/issues/8310
+-#if defined(__cpp_constinit) && !defined(__GNUC__)
++// Does not work yet with Visual Studio 2019 Update 16.10
++#if defined(__cpp_constinit) && !defined(__GNUC__) && !defined(_MSC_VER)
+ #define PROTOBUF_CONSTINIT constinit
+ #elif defined(__has_cpp_attribute)
+ #if __has_cpp_attribute(clang::require_constant_initialization)

--- a/overlay/osx/protobuf/portfile.cmake
+++ b/overlay/osx/protobuf/portfile.cmake
@@ -1,0 +1,127 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF 436bd7880e458532901c58f4d9d1ea23fa7edd52    #v3.15.8
+    SHA512 88bb9a965bccfe11a07aee2c0c16eb9cc1845ea2d7500ef6def3e1c0a8155ac4eadd0ceef4b12552960dffe95a0fc82549d1abba71ca073ab86ec5de57d9cafb
+    HEAD_REF master
+    PATCHES
+        fix-static-build.patch
+        fix-default-proto-file-path.patch
+        port_def.patch
+)
+
+string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" protobuf_BUILD_SHARED_LIBS)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" protobuf_MSVC_STATIC_RUNTIME)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib protobuf_WITH_ZLIB
+)
+
+if(VCPKG_TARGET_IS_UWP)
+    set(protobuf_BUILD_LIBPROTOC OFF)
+else()
+    set(protobuf_BUILD_LIBPROTOC ON)
+endif()
+
+if (VCPKG_DOWNLOAD_MODE)
+    # download PKGCONFIG in download mode which is used in `vcpkg_fixup_pkgconfig()` at the end of this script.
+    # download it here because `vcpkg_configure_cmake()` halts execution in download mode when running configure process.
+    vcpkg_find_acquire_program(PKGCONFIG)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/cmake
+    PREFER_NINJA
+    OPTIONS
+        -Dprotobuf_BUILD_SHARED_LIBS=${protobuf_BUILD_SHARED_LIBS}
+        -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+        -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+# It appears that at this point the build hasn't actually finished. There is probably
+# a process spawned by the build, therefore we need to wait a bit.
+
+function(protobuf_try_remove_recurse_wait PATH_TO_REMOVE)
+    file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    if (EXISTS "${PATH_TO_REMOVE}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
+        file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    endif()
+endfunction()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake
+        "\${_IMPORT_PREFIX}/bin/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "\${_IMPORT_PREFIX}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    )
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE "${DEBUG_MODULE}")
+    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" DEBUG_MODULE "${DEBUG_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake "${DEBUG_MODULE}")
+endif()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(protobuf_BUILD_PROTOC_BINARIES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_copy_tools(TOOL_NAMES protoc AUTO_CLEAN)
+    else()
+        vcpkg_copy_tools(TOOL_NAMES protoc protoc-3.15.8.0 AUTO_CLEAN)
+    endif()
+else()
+    file(COPY ${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+endif()
+
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-config.cmake
+    "if(protobuf_MODULE_COMPATIBLE)"
+    "if(ON)"
+)
+if(NOT protobuf_BUILD_LIBPROTOC)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-module.cmake
+        "_protobuf_find_libraries(Protobuf_PROTOC protoc)"
+        ""
+    )
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h
+        "\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+        "\#ifndef PROTOBUF_USE_DLLS\n\#define PROTOBUF_USE_DLLS\n\#endif // PROTOBUF_USE_DLLS\n\n\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+    )
+endif()
+
+vcpkg_copy_pdbs()
+set(packages protobuf protobuf-lite)
+foreach(_package IN LISTS packages)
+    set(_file ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${_package}.pc)
+    if(EXISTS "${_file}")
+        vcpkg_replace_string(${_file} "-l${_package}" "-l${_package}d")
+    endif()
+endforeach()
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT protobuf_BUILD_PROTOC_BINARIES)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/protobuf-targets-vcpkg-protoc.cmake ${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-targets-vcpkg-protoc.cmake COPYONLY)
+endif()
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake ${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake @ONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/overlay/osx/protobuf/portfile.cmake
+++ b/overlay/osx/protobuf/portfile.cmake
@@ -41,6 +41,10 @@ vcpkg_configure_cmake(
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
         -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
+        -DCMAKE_POLICY_DEFAULT_CMP0063=NEW
+        -DCMAKE_C_VISIBILITY_PRESET=hidden
+        -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+        -DCMAKE_VISIBILITY_INLINES_HIDDEN=TRUE
         ${FEATURE_OPTIONS}
 )
 

--- a/overlay/osx/protobuf/portfile.cmake
+++ b/overlay/osx/protobuf/portfile.cmake
@@ -31,6 +31,15 @@ if (VCPKG_DOWNLOAD_MODE)
     vcpkg_find_acquire_program(PKGCONFIG)
 endif()
 
+if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "static") 
+    set(protobuf_VISIBILITY_FLAGS 
+        -DCMAKE_POLICY_DEFAULT_CMP0063=NEW
+        -DCMAKE_C_VISIBILITY_PRESET=hidden
+        -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+        -DCMAKE_VISIBILITY_INLINES_HIDDEN=TRUE
+    )
+endif()    
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/cmake
     PREFER_NINJA
@@ -41,10 +50,7 @@ vcpkg_configure_cmake(
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
         -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
-        -DCMAKE_POLICY_DEFAULT_CMP0063=NEW
-        -DCMAKE_C_VISIBILITY_PRESET=hidden
-        -DCMAKE_CXX_VISIBILITY_PRESET=hidden
-        -DCMAKE_VISIBILITY_INLINES_HIDDEN=TRUE
+        ${protobuf_VISIBILITY_FLAGS}
         ${FEATURE_OPTIONS}
 )
 

--- a/overlay/osx/protobuf/protobuf-targets-vcpkg-protoc.cmake
+++ b/overlay/osx/protobuf/protobuf-targets-vcpkg-protoc.cmake
@@ -1,0 +1,8 @@
+# Create imported target protobuf::protoc
+add_executable(protobuf::protoc IMPORTED)
+
+# Import target "protobuf::protoc" for configuration "Release"
+set_property(TARGET protobuf::protoc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(protobuf::protoc PROPERTIES
+    IMPORTED_LOCATION_RELEASE "${Protobuf_PROTOC_EXECUTABLE}"
+)

--- a/overlay/osx/protobuf/vcpkg-cmake-wrapper.cmake
+++ b/overlay/osx/protobuf/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,16 @@
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.3)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0057 NEW)
+    if(NOT "CONFIG" IN_LIST ARGS AND NOT "NO_MODULE" IN_LIST ARGS)
+        if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+            set(Protobuf_USE_STATIC_LIBS ON)
+        else()
+            set(Protobuf_USE_STATIC_LIBS OFF)
+        endif()
+    endif()
+    cmake_policy(POP)
+endif()
+
+find_program(Protobuf_PROTOC_EXECUTABLE NAMES protoc PATHS "${CMAKE_CURRENT_LIST_DIR}/../../tools/protobuf" NO_DEFAULT_PATH)
+
+_find_package(${ARGS})

--- a/overlay/osx/protobuf/vcpkg.json
+++ b/overlay/osx/protobuf/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "protobuf",
+  "version-semver": "3.15.8",
+  "port-version": 4,
+  "description": "Protocol Buffers - Google's data interchange format",
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "dependencies": [
+    {
+      "name": "protobuf",
+      "host": true
+    }
+  ],
+  "features": {
+    "zlib": {
+      "description": "ZLib based features like Gzip streams",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}

--- a/overlay/osx/protobuf/vcpkg.json
+++ b/overlay/osx/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version-semver": "3.15.8",
-  "port-version": 7,
+  "port-version": 5,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [

--- a/overlay/osx/protobuf/vcpkg.json
+++ b/overlay/osx/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version-semver": "3.15.8",
-  "port-version": 4,
+  "port-version": 7,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [


### PR DESCRIPTION
Set visibility to "hidden" to avoid a linker warning

Apple's ld warns
"direct access in function ... to global weak symbol. The weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.