### PR TITLE
[qt5-base] fix vcpkg-cmake-wrapper to find debug libs on macOS

### DIFF
--- a/overlay/osx/qt5-base/CONTROL
+++ b/overlay/osx/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.4-10
+Version: 5.12.4-11
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/overlay/osx/qt5-base/vcpkg-cmake-wrapper.cmake
+++ b/overlay/osx/qt5-base/vcpkg-cmake-wrapper.cmake
@@ -2,7 +2,7 @@ _find_package(${ARGS})
 
 function(add_qt_library _target)
     foreach(_lib IN LISTS ARGN)
-        find_library(${_lib}_LIBRARY_DEBUG NAMES ${_lib}d PATH_SUFFIXES debug/plugins/platforms)
+        find_library(${_lib}_LIBRARY_DEBUG NAMES ${_lib}_debug ${_lib}d ${_lib} PATH_SUFFIXES debug/plugins/platforms)
         find_library(${_lib}_LIBRARY_RELEASE NAMES ${_lib} PATH_SUFFIXES plugins/platforms)
         set_property(TARGET ${_target} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
         \$<\$<NOT:\$<CONFIG:DEBUG>>:${${_lib}_LIBRARY_RELEASE}>\$<\$<CONFIG:DEBUG>:${${_lib}_LIBRARY_DEBUG}>)


### PR DESCRIPTION
Qt libraries have _debug suffix. pcre has no suffix for its debug
build.