### PR TITLE
2.4 fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - os: macos-10.15
             vcpkg_path: /Users/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
-            vcpkg_triplet: x64-osx
+            vcpkg_triplet: x64-osx-min10.12
             vcpkg_overlay_ports: overlay/osx:overlay/ports
             vcpkg_packages_extras: qt5-macextras
             vcpkg_cache: /Users/runner/.cache/vcpkg/archives

--- a/overlay/ports/hss1394/CONTROL
+++ b/overlay/ports/hss1394/CONTROL
@@ -1,5 +1,0 @@
-Source: hss1394
-Version: 1.0.0
-Homepage: https://github.com/mixxxdj/hss1394
-Description: High-speed MIDI-over-Firewire device access library for Windows and macOS.
-Supports: windows&macos

--- a/overlay/ports/hss1394/vcpkg.json
+++ b/overlay/ports/hss1394/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "hss1394",
+  "version-string": "1.0.0",
+  "port-version": 1,
+  "description": "High-speed MIDI-over-Firewire device access library for Windows and macOS",
+  "homepage": "https://github.com/mixxxdj/hss1394",
+  "supports": "windows|osx"
+}

--- a/scripts/cmake/vcpkg_configure_qmake.cmake
+++ b/scripts/cmake/vcpkg_configure_qmake.cmake
@@ -37,7 +37,12 @@ function(vcpkg_configure_qmake)
     find_program(qmake_executable NAMES qmake PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/qt5/bin" NO_DEFAULT_PATH)
 
     if(NOT qmake_executable)
-        message(FATAL_ERROR "vcpkg_configure_qmake: unable to find qmake.")
+        message(STATUS "vcpkg_configure_qmake: unable to find qmake at ${CURRENT_HOST_INSTALLED_DIR}/tools/qt5/bin")
+        message(STATUS "vcpkg_configure_qmake: trying to find qmake at ${CURRENT_INSTALLED_DIR}/tools/qt5/bin")
+        find_program(qmake_executable NAMES qmake PATHS "${CURRENT_INSTALLED_DIR}/tools/qt5/bin" NO_DEFAULT_PATH)
+        if(NOT qmake_executable)
+            message(FATAL_ERROR "vcpkg_configure_qmake: unable to find qmake.")
+        endif()
     endif()
 
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")


### PR DESCRIPTION
The 2.4 branch was broken after the PCRE project has changed the download location. 
After the merge with the microsoft/master which fixes this error, the build was broken due to faulty support entry in our hss1394 overlay. This also fixes the wrong OSX triplet, after renaming it in https://github.com/mixxxdj/vcpkg/pull/26
