### PR TITLE
[qt5-base] Require libpq

### DIFF
--- a/overlay/osx/qt5-base/vcpkg.json
+++ b/overlay/osx/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.12.4",
-  "port-version": 13,
+  "port-version": 14,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [
@@ -22,6 +22,7 @@
     "openssl",
     "pcre2",
     "sqlite3",
+    "libpq",
     {
       "name": "vcpkg-pkgconfig-get-modules",
       "host": true


### PR DESCRIPTION
This aim to fix the build failure after the GitHub workflow runner has updated the system PostgreSQL

The build of the vcpkg environment suffers the same issue as our main branch at https://github.com/mixxxdj/mixxx

```
CMake Error at /usr/local/Cellar/cmake/3.24.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PostgreSQL (missing: PostgreSQL_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.24.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.24.1/share/cmake/Modules/FindPostgreSQL.cmake:269 (find_package_handle_standard_args)
  /Users/runner/mixxx-vcpkg/scripts/buildsystems/vcpkg.cmake:824 (_find_package)
  /Users/runner/mixxx-vcpkg/installed/x64-osx-min1012/share/qt5core/vcpkg-cmake-wrapper.cmake:19 (find_package)
  /Users/runner/mixxx-vcpkg/scripts/buildsystems/vcpkg.cmake:778 (include)
  cmake/Modules/ECMQueryQmake.cmake:1 (find_package)
  cmake/Modules/ECMGeneratePriFile.cmake:83 (include)
  CMakeLists.txt:20 (include)
```

