### PR TITLE
Set `VCPKG_QT_HOST_MKSPEC` on arm64 macOS hosts explicitly

### DIFF
--- a/overlay/osx/qt5-base/cmake/find_qt_mkspec.cmake
+++ b/overlay/osx/qt5-base/cmake/find_qt_mkspec.cmake
@@ -56,6 +56,12 @@ function(find_qt_mkspec TARGET_PLATFORM_MKSPEC_OUT HOST_PLATFORM_MKSPEC_OUT EXT_
         #elseif("${CMAKE_HOST_SYSTEM}" STREQUAL "Darwin")
         #    set(_tmp_host_out "macx-clang")
         #endif()
+        if(HOST_TRIPLET MATCHES "^arm64-osx")
+            # When compiling on Apple Silicon (arm64 macOS) hosts we need to
+            # set the host mkspec explicitly (since find_qt_mkspec won't do that
+            # for us and Qt 5.12's build system will default to using Rosetta otherwise).
+            set(_tmp_host_out "macx-aarch64-clang")
+        endif()
         if(DEFINED _tmp_host_out)
             message(STATUS "Host mkspec set to: ${_tmp_host_out}") 
         else()

--- a/overlay/osx/qt5-base/portfile.cmake
+++ b/overlay/osx/qt5-base/portfile.cmake
@@ -9,6 +9,7 @@ include(install_qt)
 
 #########################
 ## Find Host and Target mkspec name for configure
+
 include(find_qt_mkspec)
 find_qt_mkspec(TARGET_MKSPEC HOST_MKSPEC HOST_TOOLS)
 set(QT_PLATFORM_CONFIGURE_OPTIONS TARGET_PLATFORM ${TARGET_MKSPEC})


### PR DESCRIPTION
This fixes an issue that prevented users from building Qt for arm64 macOS on arm64 macOS hosts directly, since Qt 5.12's build system apparently defaults to using Rosetta when the host mkspec is left undefined, causing linker errors when building `qt5-tools` (since mixing and matching x86_64 and arm64 libraries of course does not work).

In short: Another step towards making it easy to build Mixxx's dependencies on arm64 macOS hosts.

cc @daschuer, I vaguely recall you having mentioned that you already added such a check, based on `uname -m`. I couldn't find this in the tree, so I suppose it hasn't been merged yet? This patch performs the check by comparing the host triplet prefix to `arm64-osx` instead, which should hopefully be somewhat robust. (Unfortunately, vcpkg doesn't offer a `VCPKG_HOST_ARCHITECTURE` variable)