### PR TITLE
Add `arm64-osx` triplets

### DIFF
--- a/overlay/triplets/arm64-osx-min1100.cmake
+++ b/overlay/triplets/arm64-osx-min1100.cmake
@@ -1,0 +1,19 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# Mixxx loads fdk-aac dynamically at runtime. This allows the user to replace 
+# the version of fdk-aac we ship which has the patent-encumbered HE-AAC 
+#removed with another build that supports HE-AAC.
+if(${PORT} MATCHES "fdk-aac")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)
+

--- a/overlay/triplets/arm64-osx.cmake
+++ b/overlay/triplets/arm64-osx.cmake
@@ -1,0 +1,15 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# Mixxx loads fdk-aac dynamically at runtime. This allows the user to replace 
+# the version of fdk-aac we ship which has the patent-encumbered HE-AAC 
+#removed with another build that supports HE-AAC.
+if(${PORT} MATCHES "fdk-aac")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)


### PR DESCRIPTION
This is one the last missing pieces to make Apple Silicon (M*) builds possible. These triplets can be used both to compile directly on arm64 macOS machines and to cross-compile from x86_64.

As macOS 11 runners are now supported by GitHub Actions, we also no longer need to hardcode a sysroot/Xcode version, so they should be easy to reuse in different contexts.

The reason why we still have separate `arm64-osx-min1100` and `arm64-osx` triplets is convenience: When building directly on an arm64 macOS machine, the latter is set as the default triplet and lets a user who e.g. only builds for development and doesn't care about running on older macOS versions get started quickly.