### PR TITLE
Install pkg-config via brew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     - name: "[macOS] Bootstrap vcpkg"
       if: runner.os == 'macOS'
       run: |
-          brew update && brew install nasm automake
+          brew update && brew install nasm automake pkg-config
           /bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"
           xcrun --show-sdk-version
     - name: Set up cache


### PR DESCRIPTION
This fixes building on the MacOS 11 workflow runner. 

It seems that it has been broken due to an upstream change. 
https://github.com/daschuer/vcpkg/actions/runs/4069242371

This implements the suggested fix in the error message: 
```
 Could not find pkg-config.  Please install it via your package manager:

      brew install pkg-config
```
 