### PR TITLE
Backport `vcpkg_configure_qmake` to fix Qt cross-build

### DIFF
--- a/overlay/osx/qt5-base/cmake/qt_build_submodule.cmake
+++ b/overlay/osx/qt5-base/cmake/qt_build_submodule.cmake
@@ -1,3 +1,103 @@
+function(qt_configure_qmake)
+    # parse parameters such that semicolons in options arguments to COMMAND don't get erased
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        ""
+        "SOURCE_PATH"
+        "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG"
+    )
+
+    # Find qmake executable
+    find_program(qmake_executable NAMES qmake PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/qt5/bin" NO_DEFAULT_PATH)
+
+    if(NOT qmake_executable)
+        message(FATAL_ERROR "qt_configure_qmake: unable to find qmake.")
+    endif()
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        vcpkg_list(APPEND arg_OPTIONS "CONFIG-=shared" "CONFIG*=static")
+    else()
+        vcpkg_list(APPEND arg_OPTIONS "CONFIG-=static" "CONFIG*=shared")
+        vcpkg_list(APPEND arg_OPTIONS_DEBUG "CONFIG*=separate_debug_info")
+    endif()
+
+    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
+        vcpkg_list(APPEND arg_OPTIONS "CONFIG*=static-runtime")
+    endif()
+
+    if(DEFINED VCPKG_OSX_DEPLOYMENT_TARGET)
+        set(ENV{QMAKE_MACOSX_DEPLOYMENT_TARGET} ${VCPKG_OSX_DEPLOYMENT_TARGET})
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        z_vcpkg_setup_pkgconfig_path(BASE_DIRS "${CURRENT_INSTALLED_DIR}" "${CURRENT_PACKAGES_DIR}")
+
+        set(current_binary_dir "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+
+        # Cleanup build directories
+        file(REMOVE_RECURSE "${current_binary_dir}")
+
+        configure_file("${CURRENT_INSTALLED_DIR}/tools/qt5/qt_release.conf" "${current_binary_dir}/qt.conf")
+    
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
+        file(MAKE_DIRECTORY "${current_binary_dir}")
+
+        vcpkg_list(SET build_opt_param)
+        if(DEFINED arg_BUILD_OPTIONS OR DEFINED arg_BUILD_OPTIONS_RELEASE)
+            vcpkg_list(SET build_opt_param -- ${arg_BUILD_OPTIONS} ${arg_BUILD_OPTIONS_RELEASE})
+        endif()
+
+        vcpkg_execute_required_process(
+            COMMAND "${qmake_executable}" CONFIG-=debug CONFIG+=release
+                    ${arg_OPTIONS} ${arg_OPTIONS_RELEASE} ${arg_SOURCE_PATH}
+                    -qtconf "${current_binary_dir}/qt.conf"
+                    ${build_opt_param}
+            WORKING_DIRECTORY "${current_binary_dir}"
+            LOGNAME "config-${TARGET_TRIPLET}-rel"
+        )
+        message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
+        if(EXISTS "${current_binary_dir}/config.log")
+            file(REMOVE "${CURRENT_BUILDTREES_DIR}/internal-config-${TARGET_TRIPLET}-rel.log")
+            file(RENAME "${current_binary_dir}/config.log" "${CURRENT_BUILDTREES_DIR}/internal-config-${TARGET_TRIPLET}-rel.log")
+        endif()
+
+        z_vcpkg_restore_pkgconfig_path()
+    endif()
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        z_vcpkg_setup_pkgconfig_path(BASE_DIRS "${CURRENT_INSTALLED_DIR}/debug" "${CURRENT_PACKAGES_DIR}/debug")
+
+        set(current_binary_dir "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+
+        # Cleanup build directories
+        file(REMOVE_RECURSE "${current_binary_dir}")
+
+        configure_file("${CURRENT_INSTALLED_DIR}/tools/qt5/qt_debug.conf" "${current_binary_dir}/qt.conf")
+
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+        file(MAKE_DIRECTORY "${current_binary_dir}")
+
+        vcpkg_list(SET build_opt_param)
+        if(DEFINED arg_BUILD_OPTIONS OR DEFINED arg_BUILD_OPTIONS_DEBUG)
+            vcpkg_list(SET build_opt_param -- ${arg_BUILD_OPTIONS} ${arg_BUILD_OPTIONS_DEBUG})
+        endif()
+        vcpkg_execute_required_process(
+            COMMAND "${qmake_executable}" CONFIG-=release CONFIG+=debug
+                    ${arg_OPTIONS} ${arg_OPTIONS_DEBUG} ${arg_SOURCE_PATH}
+                    -qtconf "${current_binary_dir}/qt.conf"
+                    ${build_opt_param}
+            WORKING_DIRECTORY "${current_binary_dir}"
+            LOGNAME "config-${TARGET_TRIPLET}-dbg"
+        )
+        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
+        if(EXISTS "${current_binary_dir}/config.log")
+            file(REMOVE "${CURRENT_BUILDTREES_DIR}/internal-config-${TARGET_TRIPLET}-dbg.log")
+            file(RENAME "${current_binary_dir}/config.log" "${CURRENT_BUILDTREES_DIR}/internal-config-${TARGET_TRIPLET}-dbg.log")
+        endif()
+        
+        z_vcpkg_restore_pkgconfig_path()
+    endif()
+endfunction()
+
 
 function(qt_build_submodule SOURCE_PATH)
     # This fixes issues on machines with default codepages that are not ASCII compatible, such as some CJK encodings
@@ -7,7 +107,7 @@ function(qt_build_submodule SOURCE_PATH)
     get_filename_component(PYTHON2_EXE_PATH ${PYTHON2} DIRECTORY)
     vcpkg_add_to_path("${PYTHON2_EXE_PATH}")
     
-    vcpkg_configure_qmake(SOURCE_PATH ${SOURCE_PATH})
+    qt_configure_qmake(SOURCE_PATH ${SOURCE_PATH})
 
     vcpkg_build_qmake(SKIP_MAKEFILES)
     

--- a/overlay/osx/qt5-base/vcpkg.json
+++ b/overlay/osx/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.12.5",
-  "port-version": 15,
+  "port-version": 16,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [


### PR DESCRIPTION
This effectively applies 7cbfaed7e1b7d3a12aaa2122e4148387f37b1b2e, fixing the cross-compilation of Qt and thereby making it possible to cross-build Mixxx for arm64 macOS again.

@daschuer 