### PR TITLE
Added -rel suffix to the release only mixxx-deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       # Using the relative path overlay/triplets does not work (https://github.com/microsoft/vcpkg/issues/18764)
       VCPKG_OVERLAY_TRIPLETS: ${{ matrix.vcpkg_path }}/overlay/triplets
       VCPKG_OVERLAY_PORTS: ${{ matrix.vcpkg_overlay_ports }}
-      DEPS_BASE_NAME: mixxx-deps
+      DEPS_BASE_NAME: mixxx-deps-rel
       DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
       MIXXX_VERSION: 2.4
     name: ${{ matrix.vcpkg_triplet }}


### PR DESCRIPTION
This helps to distinguish the release only environment from the release/debug after download. 