### PR TITLE
[qt5-base] Add Patch to replace std::result_of with decltype

### DIFF
--- a/overlay/osx/qt5-base/patches/replace_result_of.patch
+++ b/overlay/osx/qt5-base/patches/replace_result_of.patch
@@ -1,0 +1,27 @@
+From fb6acf08bbd7a68d027282251747620b942bd1d6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=A5rten=20Nordheim?= <marten.nordheim@qt.io>
+Date: Tue, 18 Feb 2020 10:13:22 +0100
+Subject: [PATCH] Replace usage of std::result_of with decltype
+
+It's slated for removal in c++20
+
+Fixes: QTBUG-82240
+Change-Id: I7b35c151413b131ca49b2c09b6382efc3fc8ccb6
+Reviewed-by: Timur Pocheptsov <timur.pocheptsov@qt.io>
+---
+ src/corelib/kernel/qobjectdefs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/corelib/kernel/qobjectdefs.h b/src/corelib/kernel/qobjectdefs.h
+index dc2d832fe5b..becbb90a61a 100644
+--- a/src/corelib/kernel/qobjectdefs.h
++++ b/src/corelib/kernel/qobjectdefs.h
+@@ -532,7 +532,7 @@ struct Q_CORE_EXPORT QMetaObject
+     static typename std::enable_if<!QtPrivate::FunctionPointer<Func>::IsPointerToMemberFunction
+                                    && QtPrivate::FunctionPointer<Func>::ArgumentCount == -1
+                                    && !std::is_convertible<Func, const char*>::value, bool>::type
+-    invokeMethod(QObject *context, Func function, typename std::result_of<Func()>::type *ret)
++    invokeMethod(QObject *context, Func function, decltype(function()) *ret)
+     {
+         return invokeMethodImpl(context,
+                                 new QtPrivate::QFunctorSlotObjectWithNoArgs<Func, decltype(function())>(std::move(function)),

--- a/overlay/osx/qt5-base/portfile.cmake
+++ b/overlay/osx/qt5-base/portfile.cmake
@@ -37,6 +37,7 @@ qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                             patches/arm64_qiosurfacegraphicsbuffer.patch   # allow to build on arm64
                             patches/arm64_qcocoahelper.patch   # alow to build on arm64 
                             patches/arm64_send_super_stret.patch     # don't use qt_msgSendSuper_stret on arm64 
+                            patches/replace_result_of.patch # Replace usage of std::result_of with decltype
                     )
 
 # Remove vendored dependencies to ensure they are not picked up by the build


### PR DESCRIPTION
This is required, to compile the source with clang c++20