### PR TITLE
Install Google Benchmark to the 2.5 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       VCPKG_PACKAGES: >-
         ableton
+        benchmark
         chromaprint
         fdk-aac
         ffmpeg


### PR DESCRIPTION
A cherry-pick of the same 2.4 commit. 