### PR TITLE
[libmad] Detect the FPM flag according to the CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/overlay/ports/libmad/CMakeLists.txt
+++ b/overlay/ports/libmad/CMakeLists.txt
@@ -36,9 +36,36 @@ add_library(
 )
 
 target_compile_definitions(mad
-    PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H FPM_DEFAULT
+    PRIVATE _LIB _MBCS ASO_ZEROCHECK HAVE_CONFIG_H
     PRIVATE _CRT_SECURE_NO_WARNINGS
 )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(^i.86$)")
+    target_compile_definitions(mad
+        PRIVATE FPM_INTEL
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)")
+    target_compile_definitions(mad
+        PRIVATE FPM_64BIT
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+    target_compile_definitions(mad
+        PRIVATE FPM_ARM
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^mips")
+    target_compile_definitions(mad
+        PRIVATE FPM_MIPS
+    )
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
+    target_compile_definitions(mad
+        PRIVATE FPM_PPC
+    )
+else()
+    target_compile_definitions(mad
+        PRIVATE FPM_DEFAULT
+    )
+    message(WARNING "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR} unknown. Fall back to FPM_DEFAULT, loosing significant accuracy")
+endif()
 
 install(
     TARGETS mad

--- a/overlay/ports/libmad/vcpkg.json
+++ b/overlay/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version-string": "0.15.1",
-  "port-version": 11,
+  "port-version": 12,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://www.mars.org/home/rob/proj/mpeg/",
   "dependencies": [


### PR DESCRIPTION
This enables the precision 64 Bit integer math. 
Fixing bug https://github.com/mixxxdj/mixxx/issues/11888