### PR TITLE
[qt5-base] Add patch for Xcode 15

### DIFF
--- a/overlay/osx/qt5-base/patches/qmake_xcode15.patch
+++ b/overlay/osx/qt5-base/patches/qmake_xcode15.patch
@@ -1,0 +1,28 @@
+diff --git a/mkspecs/features/toolchain.prf b/mkspecs/features/toolchain.prf
+index 0c505fc965..c70f2797c8 100644
+--- a/mkspecs/features/toolchain.prf
++++ b/mkspecs/features/toolchain.prf
+@@ -288,9 +288,12 @@ isEmpty($${target_prefix}.INCDIRS) {
+                 }
+             }
+         }
+-        isEmpty(QMAKE_DEFAULT_LIBDIRS)|isEmpty(QMAKE_DEFAULT_INCDIRS): \
++        isEmpty(QMAKE_DEFAULT_INCDIRS): \
+             !integrity: \
+-                error("failed to parse default search paths from compiler output")
++                error("failed to parse default include paths from compiler output")
++        isEmpty(QMAKE_DEFAULT_LIBDIRS): \
++            !integrity:!darwin: \
++                error("failed to parse default library paths from compiler output")
+         QMAKE_DEFAULT_LIBDIRS = $$unique(QMAKE_DEFAULT_LIBDIRS)
+     } else: ghs {
+         cmd = $$QMAKE_CXX $$QMAKE_CXXFLAGS -$${LITERAL_HASH} -o /tmp/fake_output /tmp/fake_input.cpp
+@@ -412,7 +415,7 @@ isEmpty($${target_prefix}.INCDIRS) {
+         QMAKE_DEFAULT_INCDIRS = $$split(INCLUDE, $$QMAKE_DIRLIST_SEP)
+     }
+ 
+-    unix:if(!cross_compile|host_build) {
++    unix:!darwin:if(!cross_compile|host_build) {
+         isEmpty(QMAKE_DEFAULT_INCDIRS): QMAKE_DEFAULT_INCDIRS = /usr/include /usr/local/include
+         isEmpty(QMAKE_DEFAULT_LIBDIRS): QMAKE_DEFAULT_LIBDIRS = /lib /usr/lib
+     }

--- a/overlay/osx/qt5-base/portfile.cmake
+++ b/overlay/osx/qt5-base/portfile.cmake
@@ -39,6 +39,7 @@ qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                             patches/arm64_send_super_stret.patch     # don't use qt_msgSendSuper_stret on arm64 
                             patches/replace_result_of.patch # Replace usage of std::result_of with decltype
                             patches/scrollbars_style.patch # Never handle scrollbars styled with box or border changes as transient
+                            patches/qmake_xcode15.patch # Fix Xcode 15 (macOS 14 Sonoma) build, see https://github.com/Homebrew/homebrew-core/pull/145729
                     )
 
 # Remove vendored dependencies to ensure they are not picked up by the build

--- a/overlay/osx/qt5-base/portfile.cmake
+++ b/overlay/osx/qt5-base/portfile.cmake
@@ -236,13 +236,13 @@ elseif(VCPKG_TARGET_IS_OSX)
     FILE(WRITE "${SOURCE_PATH}/src/corelib/configure.json" "${_tmp_contents}")
     #list(APPEND QT_PLATFORM_CONFIGURE_OPTIONS HOST_PLATFORM ${TARGET_MKSPEC})
     list(APPEND RELEASE_OPTIONS
-            "PSQL_LIBS=${PSQL_RELEASE} ${SSL_RELEASE} ${EAY_RELEASE} -ldl -lpthread"
-            "SQLITE_LIBS=${SQLITE_RELEASE} -ldl -lpthread"
+            "PSQL_LIBS=${PSQL_RELEASE} ${SSL_RELEASE} ${EAY_RELEASE}"
+            "SQLITE_LIBS=${SQLITE_RELEASE}"
             "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE} -framework ApplicationServices"
         )
     list(APPEND DEBUG_OPTIONS
-            "PSQL_LIBS=${PSQL_DEBUG} ${SSL_DEBUG} ${EAY_DEBUG} -ldl -lpthread"
-            "SQLITE_LIBS=${SQLITE_DEBUG} -ldl -lpthread"
+            "PSQL_LIBS=${PSQL_DEBUG} ${SSL_DEBUG} ${EAY_DEBUG}"
+            "SQLITE_LIBS=${SQLITE_DEBUG}"
             "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG} -framework ApplicationServices"
         )
 endif()


### PR DESCRIPTION
This fixes an issue that prevents Qt 5 from building under Xcode 15 (macOS 14 Sonoma), namely:

```
Project ERROR: failed to parse default search paths from compiler output
```

The issue was identified by Homebrew maintainers and fixed by backporting a patch from Qt 6 (which this PR adds):

- https://github.com/Homebrew/homebrew-core/pull/145729
- https://github.com/Homebrew/homebrew-core/issues/144051
- https://bugreports.qt.io/browse/QTBUG-117225

This problem didn't surface in CI yet, since the runners use an older macOS/Xcode version. Still, it would be pretty useful to have this patch so developers can keep building 2.4 environments on their own Macs.

Marked as a draft for now, since there seems to be another error, even after applying this patch, namely:

```
ERROR: Feature 'system-sqlite' was enabled, but the pre-condition 'features.sql-sqlite && libs.sqlite3' failed.
```