### PR TITLE
Update dependency name to `ableton-link`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             check_disk_space: df -h
     env:
       VCPKG_PACKAGES: >-
-        ableton
+        ableton-link
         benchmark
         chromaprint
         fdk-aac


### PR DESCRIPTION
Upstream has renamed this port to `ableton-link` and the old `ableton` port is only kept around for compatibility:

- https://github.com/microsoft/vcpkg/pull/28892
- https://github.com/microsoft/vcpkg/pull/29434

We should probably cherry-pick this to the other branches too (2.4, 2.4-rel, 2.5).