### PR TITLE
[2.4] Update dependency name to `ableton-link`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             check_disk_space: df -h
     env:
       VCPKG_PACKAGES: >-
-        ableton
+        ableton-link
         benchmark
         chromaprint
         fdk-aac


### PR DESCRIPTION
Cherry-pick of #96 onto 2.4.