### PR TITLE
2.4 build fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
       run: ${{ matrix.vcpkg_bootstrap }}
       working-directory: ${{ matrix.vcpkg_path }}
 
+    # FFmpeg requires nasm
     - name: "[macOS] Bootstrap vcpkg"
       if: runner.os == 'macOS'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
     - name: "[macOS] Bootstrap vcpkg"
       if: runner.os == 'macOS'
       run: |
-          brew update && brew install nasm automake pkg-config
+          brew update && brew install nasm
           /bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"
           xcrun --show-sdk-version
     - name: Set up cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,12 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       working-directory: ${{ matrix.vcpkg_path }}
 
+    # python3-distutils is required for fontconfig but it has been removed in Python 3.12
+    - name: Setup Python 3.11
+      uses: actions/setup-python@v4
+      with:
+          python-version: '3.11'
+
     - name: Bootstrap vcpkg
       run: ${{ matrix.vcpkg_bootstrap }}
       working-directory: ${{ matrix.vcpkg_path }}


### PR DESCRIPTION
This fixes building after GitHub has updated the macos11 workflow runner. 
2.5 is not affected because Qt 6 no longer depends on fontconfig 