### PR TITLE
2.4: Upade libwinpthread

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -531,15 +531,15 @@ function(vcpkg_find_acquire_program program)
         elseif(CMAKE_HOST_WIN32)
             if(NOT EXISTS "${PKGCONFIG}")
                 set(VERSION 0.29.2-3)
-                set(program_version git-9.0.0.6373.5be8fcd83-1)
+                set(program_version git-11.0.0.r18.g9df2e604d-1)
                 vcpkg_acquire_msys(
                     PKGCONFIG_ROOT
                     NO_DEFAULT_PACKAGES
                     DIRECT_PACKAGES
                         "https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-${VERSION}-any.pkg.tar.zst"
                         0c086bf306b6a18988cc982b3c3828c4d922a1b60fd24e17c3bead4e296ee6de48ce148bc6f9214af98be6a86cb39c37003d2dcb6561800fdf7d0d1028cf73a4
-                        "https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-${program_version}-any.pkg.tar.zst"
-                        c89c27b5afe4cf5fdaaa354544f070c45ace5e9d2f2ebb4b956a148f61681f050e67976894e6f52e42e708dadbf730fee176ac9add3c9864c21249034c342810
+                        "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libwinpthread-${program_version}-any.pkg.tar.zst"
+                        60eccb7030039f7a42a6c6377d2cad9957c2f4693ecfa7672417a145fae21a62129475279deece9eb3e892a69a6f3d6d7e10e3fb9deda47e123e3e3d4f610d9d
                 )
             endif()
             set("${program}" "${PKGCONFIG_ROOT}/mingw32/bin/pkg-config.exe" CACHE INTERNAL "")


### PR DESCRIPTION
The original version is no longer available.
This should fix the build error in the 2.4-rel branch. 
2.4 is merged into 2.4-rel 
