### PR TITLE
Exclude `libid3tag` and `hss1394` from Linux builds

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,7 @@
     "libflac",
     {
       "name": "libid3tag",
-      "platform": "!osx"
+      "platform": "windows"
     },
     "libkeyfinder",
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,7 +15,10 @@
     "grantlee",
     "gtest",
     "hidapi",
-    "hss1394",
+    {
+      "name": "hss1394",
+      "platform": "windows | osx"
+    },
     "libdjinterop",
     "libebur128",
     "libflac",


### PR DESCRIPTION
These libraries are not supported on Linux, therefore this PR updates the platforms they are built on in the manifest.