### PR TITLE
Add Ubuntu CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "[Linux] Bootstrap vcpkg"
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y autoconf-archive nasm '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+      run: sudo apt-get install -y autoconf-archive nasm '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev mesa-common-dev
 
     - name: Check available disk space
       run: ${{ matrix.check_disk_space }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "[Linux] Bootstrap vcpkg"
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y autoconf-archive nasm '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev mesa-common-dev
+      run: sudo apt-get install -y autoconf-archive nasm '^libxcb.*-dev' libx11-xcb-dev libgl1-mesa-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev mesa-common-dev
 
     - name: Check available disk space
       run: ${{ matrix.check_disk_space }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
           - os: ubuntu-22.04
             vcpkg_path: /home/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
-            vcpkg_triplet: x64-linux
-            vcpkg_host_triplet: x64-linux
+            vcpkg_triplet: x64-linux-release
+            vcpkg_host_triplet: x64-linux-release
             vcpkg_overlay_ports: overlay/ports
             check_disk_space: df -h
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,10 @@ jobs:
           /bin/bash -c "sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer"
           xcrun --show-sdk-version
 
+    - name: "[Linux] Bootstrap vcpkg"
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y autoconf-archive nasm
+
     - name: Check available disk space
       run: ${{ matrix.check_disk_space }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "[Linux] Bootstrap vcpkg"
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y autoconf-archive nasm
+      run: sudo apt-get install -y autoconf-archive nasm '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
 
     - name: Check available disk space
       run: ${{ matrix.check_disk_space }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,13 @@ jobs:
             vcpkg_host_triplet: x64-osx-min1015
             vcpkg_overlay_ports: overlay/osx:overlay/ports
             check_disk_space: df -h
+          - os: ubuntu-22.04
+            vcpkg_path: /home/runner/mixxx-vcpkg
+            vcpkg_bootstrap: ./bootstrap-vcpkg.sh
+            vcpkg_triplet: x64-linux
+            vcpkg_host_triplet: x64-linux
+            vcpkg_overlay_ports: overlay/ports
+            check_disk_space: df -h
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,7 @@
     "libflac",
     {
       "name": "libid3tag",
-      "platform": "!osx"
+      "platform": "windows"
     },
     "libkeyfinder",
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,7 +15,10 @@
     "grantlee",
     "gtest",
     "hidapi",
-    "hss1394",
+    {
+      "name": "hss1394",
+      "platform": "windows | osx"
+    },
     "libdjinterop",
     "libebur128",
     "libflac",


### PR DESCRIPTION
### Based on #112 

To avoid regressing on the Linux build (e.g. for static builds of Mixxx), this PR adds CI for Ubuntu. This is useful even if we don't use it in the official release pipeline as it helps us catch issues such as #112 early.