### PR TITLE
Add arm64 macOS release CI to regular 2.5 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,13 @@ jobs:
             vcpkg_host_triplet: x64-osx-min1015
             vcpkg_overlay_ports: overlay/osx:overlay/ports
             check_disk_space: df -h
+          - os: macos-11
+            vcpkg_path: /Users/runner/mixxx-vcpkg
+            vcpkg_bootstrap: ./bootstrap-vcpkg.sh
+            vcpkg_triplet: arm64-osx-min1100-release
+            vcpkg_host_triplet: x64-osx-min1015-release
+            vcpkg_overlay_ports: overlay/osx:overlay/ports
+            check_disk_space: df -h
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}

--- a/overlay/triplets/arm64-osx-min1100-release.cmake
+++ b/overlay/triplets/arm64-osx-min1100-release.cmake
@@ -1,0 +1,18 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# Mixxx loads fdk-aac dynamically at runtime. This allows the user to replace 
+# the version of fdk-aac we ship which has the patent-encumbered HE-AAC 
+#removed with another build that supports HE-AAC.
+if(${PORT} MATCHES "fdk-aac")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
+
+set(VCPKG_BUILD_TYPE release)

--- a/overlay/triplets/x64-osx-min1015-release.cmake
+++ b/overlay/triplets/x64-osx-min1015-release.cmake
@@ -1,0 +1,18 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# Mixxx loads fdk-aac dynamically at runtime. This allows the user to replace 
+# the version of fdk-aac we ship which has the patent-encumbered HE-AAC 
+#removed with another build that supports HE-AAC.
+if(${PORT} MATCHES "fdk-aac")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES x86_64)
+
+set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
As discussed in https://github.com/mixxxdj/vcpkg/pull/111#issuecomment-1928490919, here is a small patch that adds the arm64 macOS cross-build to the regular 2.5 branch for testing. Note that this is only a release build, since debug cross-builds are too time/memory intensive for the GitHub runners.