### PR TITLE
Bump manifest version to 2.5.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mixxx",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Mixxx is free cross platform DJ software",
   "homepage": "https://mixxx.org/",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
A minor update to reflect that the manifest represents the dependencies for Mixxx 2.5.