### PR TITLE
Add support for building 2.5 environment with Qt 5 via optional `qt5` feature

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,17 @@
   "supports": "!uwp",
   "default-features": ["qt6"],
   "features": {
+    "qt5": {
+      "description": "Build with Qt 5",
+      "dependencies": [
+        "qt5-base",
+        "qt5-declarative",
+        "qt5-script",
+        "qt5-svg",
+        "qt5-translations",
+        "qtkeychain"
+      ]
+    },
     "qt6": {
       "description": "Build with Qt 6",
       "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,20 @@
   "homepage": "https://mixxx.org/",
   "license": "GPL-2.0-or-later",
   "supports": "!uwp",
+  "default-features": ["qt6"],
+  "features": {
+    "qt6": {
+      "description": "Build with Qt 6",
+      "dependencies": [
+        "qt5compat",
+        "qtbase",
+        "qtdeclarative",
+        "qtsvg",
+        "qttranslations",
+        "qtkeychain-qt6"
+      ]
+    }
+  },
   "dependencies": [
     "ableton-link",
     "benchmark",
@@ -52,12 +66,6 @@
     "portmidi",
     "protobuf",
     "pthreads",
-    "qt5compat",
-    "qtbase",
-    "qtdeclarative",
-    "qtsvg",
-    "qttranslations",
-    "qtkeychain-qt6",
     "rubberband",
     "soundtouch",
     "taglib",


### PR DESCRIPTION
This modularizes the Qt dependencies into two features `qt5` and `qt6` with `qt6` enabled by default. Thus the default build should work exactly as before, but users can now build with Qt 5 with

```sh
./vcpkg install --x-no-default-features --x-feature qt5 ...
```