### PR TITLE
feat: add missing deps used in QML offscreen rendering

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,7 +26,9 @@
         "qtdeclarative",
         "qtsvg",
         "qttranslations",
-        "qtkeychain-qt6"
+        "qtkeychain-qt6",
+        "qtquick3d",
+        "qtquickcontrols2"
       ]
     }
   },


### PR DESCRIPTION
This is an attempt to fix [this issue reported on Zulip](https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Traktor.20Kontrol.20S4.20MK3/near/423666459)