### PR TITLE
[portmidi] Scope alsa dependency to Linux

### DIFF
--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "portmidi",
   "version": "2.0.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs.",
   "homepage": "https://github.com/PortMidi/portmidi",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "alsa",
-      "platform": "!(windows | osx)"
+      "platform": "linux | android | freebsd | openbsd"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6618,7 +6618,7 @@
     },
     "portmidi": {
       "baseline": "2.0.4",
-      "port-version": 2
+      "port-version": 3
     },
     "portsmf": {
       "baseline": "239",

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e836f32941f2eb402cecca7bff1e0ec566c4287",
+      "version": "2.0.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "73cae77fb0424c85894d1165fd2cc162bd4cd98a",
       "version": "2.0.4",
       "port-version": 2


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/vcpkg/pull/36613 onto 2.5 so we can progress with #116.