### PR TITLE
[libflac] Fix WASM build by disabling stack protector via feature

### DIFF
--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -17,6 +17,7 @@ endif()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         asm WITH_ASM
+        stack-protector WITH_STACK_PROTECTOR
 )
 
 vcpkg_cmake_configure(

--- a/ports/libflac/vcpkg.json
+++ b/ports/libflac/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libflac",
   "version": "1.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for manipulating FLAC files",
   "homepage": "https://xiph.org/flac/",
   "license": "BSD-3-Clause",
@@ -14,6 +14,12 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "stack-protector",
+      "platform": "!emscripten"
     }
   ],
   "features": {

--- a/ports/libflac/vcpkg.json
+++ b/ports/libflac/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libflac",
   "version": "1.4.3",
+  "port-version": 1,
   "description": "Library for manipulating FLAC files",
   "homepage": "https://xiph.org/flac/",
   "license": "BSD-3-Clause",
@@ -19,6 +20,10 @@
     "asm": {
       "description": "Use any assembly optimization routines",
       "supports": "x86"
+    },
+    "stack-protector": {
+      "description": "Build with stack smashing protection",
+      "supports": "!emscripten"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "libflac": {
       "baseline": "1.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libfontenc": {
       "baseline": "1.1.4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "libflac": {
       "baseline": "1.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "libfontenc": {
       "baseline": "1.1.4",

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a92a3397dfb70e6eec94fab7b3665a1288d9f7bd",
+      "version": "1.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "8a05fdac2efaa1a739e13289a2bec7d6d32e84a3",
       "version": "1.4.3",
       "port-version": 1

--- a/versions/l-/libflac.json
+++ b/versions/l-/libflac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a05fdac2efaa1a739e13289a2bec7d6d32e84a3",
+      "version": "1.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "b03480bcc5f27cdc9a5f51fef012f880f1b0bf8d",
       "version": "1.4.3",
       "port-version": 0


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/vcpkg/pull/37086 onto 2.5.