### PR TITLE
[libmad] Fix WASM build by disabling asm-based optimizations (#37088)

### DIFF
--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -11,9 +11,26 @@ vcpkg_download_distfile(
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        aso ASO
+)
+
+set(EXTRA_OPTIONS)
+
+# Avoid architecture-specific assembly when targeting WASM.  The upstream
+# CMakeLists incorrectly recognizes the CPU as an Intel/64-bit CPU, therefore
+# we have to override these flags:
+# https://codeberg.org/tenacityteam/libmad/src/commit/84ba587793d61caadf6d1f6c0d94c3e165874a50/CMakeLists.txt
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    list(APPEND EXTRA_OPTIONS "-DFPM_64BIT=OFF -DFPM_INTEL=OFF -DFPM_DEFAULT=ON")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
+        ${EXTRA_OPTIONS}
         -DEXAMPLE=OFF
 )
 

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.16.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://codeberg.org/tenacityteam/libmad",
   "dependencies": [
@@ -13,5 +13,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "aso": {
+      "description": "Enable CPU architecture-specific optimizations (x86, ARM and MIPS only)",
+      "supports": "x86 | x64 | arm"
+    }
+  }
 }

--- a/ports/libmad/vcpkg.json
+++ b/ports/libmad/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libmad",
   "version": "0.16.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "high-quality MPEG audio decoder",
   "homepage": "http://codeberg.org/tenacityteam/libmad",
   "dependencies": [
@@ -12,6 +12,12 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "aso",
+      "platform": "x86 | x64 | arm"
     }
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4406,7 +4406,7 @@
     },
     "libmad": {
       "baseline": "0.16.4",
-      "port-version": 2
+      "port-version": 3
     },
     "libmagic": {
       "baseline": "5.40",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4406,7 +4406,7 @@
     },
     "libmad": {
       "baseline": "0.16.4",
-      "port-version": 1
+      "port-version": 2
     },
     "libmagic": {
       "baseline": "5.40",

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69c818a7eba6f5da1e09077064ee37a12887ecf0",
+      "version": "0.16.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "204aa1729bb363c40a79cbcdb3beab84fa4bd03e",
       "version": "0.16.4",
       "port-version": 2

--- a/versions/l-/libmad.json
+++ b/versions/l-/libmad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "204aa1729bb363c40a79cbcdb3beab84fa4bd03e",
+      "version": "0.16.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "7016c2c6c5e65a6420a176aa97696897bb134c40",
       "version": "0.16.4",
       "port-version": 1


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/vcpkg/pull/37088 onto 2.5.