### PR TITLE
Scope `libid3tag` and `libmad` to `!osx & !ios` (to fix Wasm MP3 support)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -49,12 +49,12 @@
     "libflac",
     {
       "name": "libid3tag",
-      "platform": "windows"
+      "platform": "!osx & !ios"
     },
     "libkeyfinder",
     {
       "name": "libmad",
-      "platform": "!osx"
+      "platform": "!osx & !ios"
     },
     "libmodplug",
     "libogg",


### PR DESCRIPTION
From what I understand, these libraries are only skipped on Apple platforms because `SoundSourceCoreAudio` already takes care of this, and are otherwise required for MP3 support.

Therefore `!osx & !ios` should be the correct bound, which would also handle the Emscripten/Wasm case correctly (currently `libid3tag` is only built on Windows, thus MP3 decoding doesn't work on Wasm).