### PR TITLE
[icu] Cherry-pick Wasm fixes to 2.5

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -33,8 +33,11 @@ list(APPEND CONFIGURE_OPTIONS --disable-samples --disable-tests --disable-layout
 list(APPEND CONFIGURE_OPTIONS_RELEASE --disable-debug --enable-release)
 list(APPEND CONFIGURE_OPTIONS_DEBUG  --enable-debug --disable-release)
 
-set(RELEASE_TRIPLET ${TARGET_TRIPLET}-rel)
-set(DEBUG_TRIPLET ${TARGET_TRIPLET}-dbg)
+set(CONFIG_TRIPLETS)
+list(APPEND CONFIG_TRIPLETS ${TARGET_TRIPLET}-rel)
+if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+  list(APPEND CONFIG_TRIPLETS ${TARGET_TRIPLET}-dbg)
+endif()
 
 if("tools" IN_LIST FEATURES)
   list(APPEND CONFIGURE_OPTIONS --enable-tools)
@@ -89,7 +92,7 @@ if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     endif()
 
     #31680: Fix @rpath in both debug and release build
-    foreach(CONFIG_TRIPLE IN ITEMS ${DEBUG_TRIPLET} ${RELEASE_TRIPLET})
+    foreach(CONFIG_TRIPLE IN LISTS CONFIG_TRIPLETS)
         # add ID_PREFIX to libicudata libicui18n libicuio libicutu libicuuc
         foreach(LIB_NAME IN ITEMS libicudata libicui18n libicuio ${LIBICUTU_RPATH} libicuuc)
             vcpkg_execute_build_process(
@@ -178,7 +181,7 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/tools/icu/debug")
 
 # To cross compile, we need some files at specific positions. So lets copy them
-file(GLOB CROSS_COMPILE_DEFS "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/config/icucross.*")
+file(GLOB CROSS_COMPILE_DEFS "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/config/icucross.*")
 file(INSTALL ${CROSS_COMPILE_DEFS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/config")
 
 file(GLOB RELEASE_DLLS "${CURRENT_PACKAGES_DIR}/lib/*icu*${ICU_VERSION_MAJOR}.dll")

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -19,10 +19,21 @@ vcpkg_extract_source_archive(SOURCE_PATH
         mingw-dll-install.patch
         disable-static-prefix.patch # https://gitlab.kitware.com/cmake/cmake/-/issues/16617; also mingw.
         fix-win-build.patch
+        vcpkg-cross-data.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)
 set(ENV{PYTHON} "${PYTHON3}")
+
+vcpkg_list(SET CONFIGURE_OPTIONS)
+vcpkg_list(SET CONFIGURE_OPTIONS_RELEASE)
+vcpkg_list(SET CONFIGURE_OPTIONS_DEBUG)
+vcpkg_list(SET BUILD_OPTIONS)
+
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_list(APPEND CONFIGURE_OPTIONS --disable-extras)
+    vcpkg_list(APPEND BUILD_OPTIONS "PKGDATA_OPTS=--without-assembly -O ../data/icupkg.inc")
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND CONFIGURE_OPTIONS --enable-icu-build-win)
@@ -144,7 +155,7 @@ if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 
 endif()
 
-vcpkg_install_make()
+vcpkg_install_make(OPTIONS ${BUILD_OPTIONS})
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/share"

--- a/ports/icu/vcpkg-cross-data.patch
+++ b/ports/icu/vcpkg-cross-data.patch
@@ -1,0 +1,13 @@
+diff --git a/source/configure.ac b/source/configure.ac
+index 1bd5871..c508f48 100644
+--- a/source/configure.ac
++++ b/source/configure.ac
+@@ -1151,7 +1151,7 @@ AC_ARG_ENABLE(fuzzer,
+ 	fuzzer=false)
+ ICU_CONDITIONAL(FUZZER, test "$fuzzer" = true)
+ 
+-ICU_CONDITIONAL(DATA, test "$tools" = true || test "$cross_compiling" = "yes")
++ICU_CONDITIONAL(DATA, test "$tools" = true || test "$cross_compiling" = "yes" || test -n "$cross_buildroot")
+ 
+ AC_ARG_WITH(data-packaging,
+ 	[  --with-data-packaging     specify how to package ICU data. Possible values:

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "icu",
   "version": "73.1",
+  "port-version": 1,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "icu",
   "version": "73.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Mature and widely used Unicode and localization library.",
   "homepage": "https://icu.unicode.org/home",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3322,7 +3322,7 @@
     },
     "icu": {
       "baseline": "73.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3322,7 +3322,7 @@
     },
     "icu": {
       "baseline": "73.1",
-      "port-version": 1
+      "port-version": 2
     },
     "ideviceinstaller": {
       "baseline": "2023-07-21",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "deb5694d7965a264d6eb579df49aff4fe6362c24",
+      "version": "73.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "acc3cf9137af5fc8fdd3e8607377026cf88f144d",
       "version": "73.1",
       "port-version": 0

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6ac20c2420a4f7118d5db326c8c599e50b2c5a4",
+      "version": "73.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "deb5694d7965a264d6eb579df49aff4fe6362c24",
       "version": "73.1",
       "port-version": 1


### PR DESCRIPTION
The [latest build errors from the Wasm branch](https://github.com/mixxxdj/vcpkg/actions/runs/8380584291/job/22950128900?pr=140) look suspiciously similar to https://github.com/microsoft/vcpkg/issues/35464, therefore this cherry-picks the ICU patches from

- https://github.com/microsoft/vcpkg/pull/35529
- https://github.com/microsoft/vcpkg/pull/34539 (also included since the other patch is based on this one)