### PR TITLE
Raise minimum macOS version to 11 (Qt6.5 requirement) and use AVX instruction set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,14 @@ jobs:
           - os: macos-11
             vcpkg_path: /Users/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
-            vcpkg_triplet: x64-osx-min1015
-            vcpkg_host_triplet: x64-osx-min1015
+            vcpkg_triplet: x64-osx-min1100
+            vcpkg_host_triplet: x64-osx-min1100
             check_disk_space: df -h
           - os: macos-11
             vcpkg_path: /Users/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
             vcpkg_triplet: arm64-osx-min1100-release
-            vcpkg_host_triplet: x64-osx-min1015-release
+            vcpkg_host_triplet: x64-osx-min1100-release
             check_disk_space: df -h
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}

--- a/overlay/triplets/x64-osx-min1100-release.cmake
+++ b/overlay/triplets/x64-osx-min1100-release.cmake
@@ -13,5 +13,12 @@ endif()
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+# Minimum supported macOS version as target platform for Qt6.5 is 11
+# https://doc.qt.io/qt-6.5/supported-platforms.html#desktop-platforms
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
+# All Apple computer supported by macOS 11, have processors with AVX instruction set
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx")
+
+set(VCPKG_BUILD_TYPE release)

--- a/overlay/triplets/x64-osx-min1100.cmake
+++ b/overlay/triplets/x64-osx-min1100.cmake
@@ -13,6 +13,10 @@ endif()
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+# Minimum supported macOS version as target platform for Qt6.5 is 11
+# https://doc.qt.io/qt-6.5/supported-platforms.html#desktop-platforms
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
-set(VCPKG_BUILD_TYPE release)
+# All Apple computer supported by macOS 11, have processors with AVX instruction set
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx")


### PR DESCRIPTION
The 2.5 buildenv contains Qt6.5, which has macOS 11 as minimum system requirement: https://doc.qt.io/qt-6.5/supported-platforms.html#desktop-platforms

Therefore I raised the mimimum required macOS version to 11.0.

The x86_64 computer models supported by macOS 11 are very limited, I checked, that each of them has a processor with AVX instruction set. Therefore AVX is set as default for macOS now.

I've no Mac myself and can't verify/measure that the setting does, what it should. 

