### PR TITLE
[libdjinterop] Update to 0.21.0 (#38888)

### DIFF
--- a/ports/libdjinterop/portfile.cmake
+++ b/ports/libdjinterop/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xsco/libdjinterop
     REF "${VERSION}"
-    SHA512 f470ff83aaa0afcf2262bca7683cd9ee07b50877f67cb655f1ee1cdef183d7f7c9aeba9e94b6291bc9119485ee16a7f41f84a895d6422a7c672028461abe728b
+    SHA512 c2784ffc6b0ddc9ad92a227621bb00cd1c88aa8f8abe82401774102f9be16dfbe9f0745523d517594faecba60b650a53613c7867afe57e6bcd8a2cc6288dd9ff
     HEAD_REF master
 )
 

--- a/ports/libdjinterop/vcpkg.json
+++ b/ports/libdjinterop/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdjinterop",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "C++ library for access to DJ record libraries. Currently only supports Denon Engine Prime databases",
   "homepage": "https://github.com/xsco/libdjinterop",
   "license": "LGPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3897,7 +3897,7 @@
       "port-version": 1
     },
     "libdjinterop": {
-      "baseline": "0.20.3",
+      "baseline": "0.21.0",
       "port-version": 0
     },
     "libdmx": {

--- a/versions/l-/libdjinterop.json
+++ b/versions/l-/libdjinterop.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c643a7969afe7b095d0c6e779adbe14b09ad39d0",
+      "version": "0.21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "51bf8341270436bf73d01f98a72df0204ddbfeff",
       "version": "0.20.3",
       "port-version": 0


### PR DESCRIPTION
Adds version 0.21.0 of libdjinterop.

- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [x] The "supports" clause reflects platforms that may be fixed by this new version.
- [x] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [x] Any patches that are no longer applied are deleted from the port's directory.
- [x] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [x] Only one version is added to each modified port's versions file.
