### PR TITLE
Native arm64-osx build on macos-14 runner and Xcode 15.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,30 +13,44 @@ jobs:
       matrix:
         include:
           - os: windows-2019
+            deps_name: x64-windows
             vcpkg_path: C:\mixxx-vcpkg
             vcpkg_bootstrap: .\bootstrap-vcpkg.bat
             vcpkg_triplet: x64-windows
             vcpkg_host_triplet: x64-windows           
             check_disk_space: Get-PSDrive
           - os: macos-13
+            deps_name: x64-osx
             vcpkg_path: /Users/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
             vcpkg_triplet: x64-osx-min1100
             vcpkg_host_triplet: x64-osx-min1100
+            developer_dir: /Applications/Xcode_14.2.app/Contents/Developer
             check_disk_space: df -h
           - os: macos-13
+            deps_name: arm64-osx-cross
             vcpkg_path: /Users/runner/mixxx-vcpkg
             vcpkg_bootstrap: ./bootstrap-vcpkg.sh
-            vcpkg_triplet: arm64-osx-min1100-release
+            vcpkg_triplet: arm64-osx-min1100
             vcpkg_host_triplet: x64-osx-min1100-release
+            developer_dir: /Applications/Xcode_14.2.app/Contents/Developer
+            check_disk_space: df -h
+          - os: macos-14
+            deps_name: arm64-osx
+            vcpkg_path: /Users/runner/mixxx-vcpkg
+            vcpkg_bootstrap: ./bootstrap-vcpkg.sh
+            vcpkg_triplet: arm64-osx-min1100
+            vcpkg_host_triplet: arm64-osx-min1100
+            developer_dir: /Applications/Xcode_15.4.app/Contents/Developer
+            brew_extra: libtool
             check_disk_space: df -h
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}
       VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       DEPS_BASE_NAME: mixxx-deps
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: ${{ matrix.developer_dir }}
       MIXXX_VERSION: 2.5
-    name: ${{ matrix.vcpkg_triplet }}
+    name: ${{ matrix.deps_name }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out git repository
@@ -85,8 +99,8 @@ jobs:
     - name: "[macOS] Bootstrap vcpkg"
       if: runner.os == 'macOS'
       run: |
-          brew update && brew install nasm autoconf-archive
-          /bin/bash -c "sudo xcode-select --switch /Applications/Xcode_14.2.app/Contents/Developer"
+          brew update && brew install automake nasm autoconf-archive ${{ matrix.brew_extra }}
+          sudo xcode-select --switch "$DEVELOPER_DIR"
           xcrun --show-sdk-version
 
     - name: Check available disk space
@@ -159,11 +173,11 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: logs-${{ matrix.vcpkg_triplet }}
+        name: logs-${{ matrix.deps_name }}
         path: ${{ matrix.vcpkg_path  }}/buildtrees/**/*.log
 
     - name: Create buildenv archive
-      run: ./vcpkg export --vcpkg-root=${{ matrix.vcpkg_path }} --x-all-installed --zip --output=${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.vcpkg_triplet }}-${{ steps.vars.outputs.sha_short }} --output-dir=${{ matrix.vcpkg_path }}
+      run: ./vcpkg export --vcpkg-root=${{ matrix.vcpkg_path }} --x-all-installed --zip --output=${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }} --output-dir=${{ matrix.vcpkg_path }}
       working-directory: ${{ matrix.vcpkg_path }}
 
     - name: "[Windows] Install additional tools"
@@ -177,7 +191,7 @@ jobs:
 
     - name: "Upload build to downloads.mixxx.org"
       if: github.event_name == 'push' && env.SSH_PASSWORD != null
-      run: bash .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.vcpkg_triplet }}-${{ steps.vars.outputs.sha_short }}.zip
+      run: bash .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
       working-directory: ${{ matrix.vcpkg_path }}
       env:
         DESTDIR: public_html/downloads/dependencies
@@ -192,8 +206,8 @@ jobs:
     - name: Upload GitHub Actions artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.vcpkg_triplet }}-${{ steps.vars.outputs.sha_short }}
-        path: ${{ matrix.vcpkg_path }}/${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.vcpkg_triplet }}-${{ steps.vars.outputs.sha_short }}.zip
+        name: ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}
+        path: ${{ matrix.vcpkg_path }}/${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
 
     # Workaround for https://github.com/actions/cache/issues/531
     - name: Use system tar & zstd from Chocolatey for caching


### PR DESCRIPTION
This adds a new dependency package for home builds on Apple Silicon device. 
To avoid confusion, I have renamed the packages, removed the unimportant "mixx1100" part and added "cross" in case of cross-compile.  
I consider to entirely drop the cross-compile environment in 2.6. but I don't intend to do it in the stable 2.5 branch, to not introduce such a mayor change. 