### PR TITLE
Don't install CMake as additional CI workflow step - it's later overwritten by VCPKG anyway

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,12 +75,6 @@ jobs:
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       working-directory: ${{ matrix.vcpkg_path }}
 
-    # update cmake to 2.29.2 to work around https://github.com/microsoft/vcpkg/issues/37968   
-    - name: "Set up cmake"
-      uses: jwlawson/actions-setup-cmake@v2.0
-      with:
-          cmake-version: "3.29.2"
-
     - name: Bootstrap vcpkg
       run: ${{ matrix.vcpkg_bootstrap }}
       working-directory: ${{ matrix.vcpkg_path }}


### PR DESCRIPTION
This step has no influence, just makes log noise:
![grafik](https://github.com/user-attachments/assets/ccd0b0d4-3905-4606-9e34-43b2fae16cab)
