### PR TITLE
Replace MSYS tools by native versions to support Windows on ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,13 +189,14 @@ jobs:
       env:
         SSH_PASSWORD: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD }}
       run: |
-        $Env:PATH="C:\msys64\usr\bin;$Env:PATH"
-        pacman -S --noconfirm coreutils bash rsync openssh
+        $Env:PATH="C:\ProgramData\chocolatey\bin;$Env:PATH"
+        choco install rsync -y
         Add-Content -Path "$Env:GITHUB_ENV" -Value "PATH=$Env:PATH"
 
     - name: "Upload build to downloads.mixxx.org"
       if: github.event_name == 'push' && env.SSH_PASSWORD != null
-      run: bash .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
+      shell: bash
+      run: .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
       working-directory: ${{ matrix.vcpkg_path }}
       env:
         DESTDIR: public_html/downloads/dependencies


### PR DESCRIPTION
- Update build.yml to install rsync via Chocolatey
- Use bash from 'Git or Windows' instead of the MSYS version
