### PR TITLE
chore: add qtmultimedia for QML

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,6 +29,7 @@
           ]      
         },
         "qtdeclarative",
+        "qtmultimedia",
         "qtsvg",
         "qttranslations",
         "qtkeychain-qt6"


### PR DESCRIPTION
This is a necessary dependency to display screen rendering in QML ([source](https://github.com/mixxxdj/mixxx/blob/8e3e57bf3b624198c70e2cb1a768773c44c9dbe4/res/qml/Settings/ControllerScreens.qml#L28))

Blocker for https://github.com/mixxxdj/mixxx/pull/14697