### PR TITLE
chore(ci): retry artifact upload to download server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,8 +214,14 @@ jobs:
 
     - name: "Upload build to downloads.mixxx.org"
       if: github.event_name == 'push' && env.SSH_PASSWORD != null
-      run: bash .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
-      working-directory: ${{ matrix.vcpkg_path }}
+      # Use retry loop to work around intermittent transfer issue
+      uses: nick-fields/retry@9417ab499314dfe692edb043ded2ff9b3f5f0a68 # v3
+      with:
+        max_attempts: 10
+        retry_wait_seconds: 5
+        command: |
+          cd ${{ matrix.vcpkg_path }}
+          bash .github/deploy.sh ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
       env:
         DESTDIR: public_html/downloads/dependencies
         OS: ${{ runner.os }}


### PR DESCRIPTION
Noticed a few failure lately, which appears to be intermittent (always work upon retry). This tweak should allow us to save some time, effort and resources!