### PR TITLE
2.5 - Update Windows GitHub runner image to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             deps_name: x64-windows
             vcpkg_path: C:\mixxx-vcpkg
             vcpkg_bootstrap: .\bootstrap-vcpkg.bat


### PR DESCRIPTION
Closes: https://github.com/mixxxdj/mixxx/issues/15002