### PR TITLE
Revert "Install TrustedSigning PowerShell modul"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,16 +109,7 @@ jobs:
     - name: Build packages  
       run: ./vcpkg install --vcpkg-root=${{ matrix.vcpkg_path }} --clean-after-build --recurse --feature-flags="-compilertracking,manifests,registries,versions" --x-abi-tools-use-exact-versions
       working-directory: ${{ matrix.vcpkg_path }}
-
-    - name: "[Windows] Install TrustedSigning"
-      env:
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-      shell: 'pwsh'   
-      run: |
-        Install-Module -Name TrustedSigning -Scope CurrentUser -Force -Repository PSGallery
-        Import-Module TrustedSigning
-        
+      
     - name: "[Windows] Sign release DLLs"
       env:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
This is a back-port of the same PR for 2.6 #180 but here for 2.5. 

Also the 2,5 branch has been confirmed working without this here: 
https://github.com/daschuer/vcpkg/actions/runs/15944336081