### PR TITLE
Disable compressing of buildenv artifacts by GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,10 +176,11 @@ jobs:
 
     - name: Upload GitHub Actions artifacts of build logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.deps_name }}
         path: ${{ matrix.vcpkg_path  }}/buildtrees/**/*.log
+        archive: true
 
     - name: Create buildenv archive
       run: ./vcpkg export --vcpkg-root=${{ matrix.vcpkg_path }} --x-all-installed --zip --output=${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }} --output-dir=${{ matrix.vcpkg_path }}
@@ -226,10 +227,11 @@ jobs:
         UPLOAD_ID: ${{ github.run_id }}
 
     - name: Upload GitHub Actions artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}
         path: ${{ matrix.vcpkg_path }}/${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
+        archive: false
 
     # Workaround for https://github.com/actions/cache/issues/531
     - name: Use system tar & zstd from Chocolatey for caching


### PR DESCRIPTION
Until now we have a .zip in a .zip which makes the process unecessary complicated and the checksums differ between the GitHub artifact download and our download server.
This should be fixed by updating actions/upload-artifac to v7, which allows to disable the double-ziping in case of sngle files.
Note that we've multiple log files, therefore we need ziping there.