### PR TITLE
No double-zip and enable dependabot for 2.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.7"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,10 +296,11 @@ jobs:
 
     - name: Upload GitHub Actions artifacts of build logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.deps_name }}
         path: ${{ matrix.vcpkg_path  }}/buildtrees/**/*.log
+        archive: true
 
     - name: Create buildenv archive
       run: ./vcpkg export --vcpkg-root=${{ matrix.vcpkg_path }} --x-all-installed --zip --output=${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }} --output-dir=${{ matrix.vcpkg_path }}
@@ -346,10 +347,11 @@ jobs:
         UPLOAD_ID: ${{ github.run_id }}
 
     - name: Upload GitHub Actions artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}
         path: ${{ matrix.vcpkg_path }}/${{ env.DEPS_BASE_NAME }}-${{ env.MIXXX_VERSION }}-${{ matrix.deps_name }}-${{ steps.vars.outputs.sha_short }}.zip
+        archive: false
 
     # Workaround for https://github.com/actions/cache/issues/531
     - name: Use system tar & zstd from Chocolatey for caching


### PR DESCRIPTION
Same changes as for 2.6, but adapted for 2.7