### PR TITLE
Update azure/trusted-signing-action@v2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,13 +119,13 @@ jobs:
       env:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-      uses: azure/trusted-signing-action@v0.5.11
+      uses: azure/trusted-signing-action@v2.0.0
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
         endpoint: https://weu.codesigning.azure.net/
-        trusted-signing-account-name: mixxx
+        signing-account-name: mixxx
         certificate-profile-name: mixxx
         files-folder: ${{ matrix.vcpkg_path }}/vcpkg_installed/${{ matrix.vcpkg_triplet }}/bin
         files-folder-filter: dll
@@ -138,13 +138,13 @@ jobs:
       env:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-      uses: azure/trusted-signing-action@v0.5.11
+      uses: azure/trusted-signing-action@v2.0.0
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
         endpoint: https://weu.codesigning.azure.net/
-        trusted-signing-account-name: mixxx
+        signing-account-name: mixxx
         certificate-profile-name: mixxx
         files-folder: ${{ matrix.vcpkg_path }}/vcpkg_installed/${{ matrix.vcpkg_triplet }}/Qt6/plugins
         files-folder-filter: dll
@@ -158,13 +158,13 @@ jobs:
       env:
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-      uses: azure/trusted-signing-action@v0.5.11
+      uses: azure/trusted-signing-action@v2.0.0
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
         endpoint: https://weu.codesigning.azure.net/
-        trusted-signing-account-name: mixxx
+        signing-account-name: mixxx
         certificate-profile-name: mixxx
         files-folder: ${{ matrix.vcpkg_path }}/vcpkg_installed/${{ matrix.vcpkg_triplet }}/Qt6/qml
         files-folder-filter: dll


### PR DESCRIPTION
This fixes a deprecation warning