### PR TITLE
Enable the Videotoolbox framework on APPLE platforms, which is needed for QtMultimedia from Qt6.10

### DIFF
--- a/overlay/ports/ffmpeg/portfile.cmake
+++ b/overlay/ports/ffmpeg/portfile.cmake
@@ -98,6 +98,21 @@ if("fedora-ffmpeg-free-safe" IN_LIST FEATURES)
             "libavcodec/audiotoolboxdec.c"
             "libavcodec/audiotoolboxenc.c"
             "libavdevice/audiotoolbox.m"
+            "libavdevice/avfoundation.m"
+            "libavfilter/vf_coreimage.m"
+            "libavfilter/vf_scale_vt.c"
+            "libavutil/hwcontext_videotoolbox.c"
+            "libavcodec/proresdata.c"
+            "libavcodec/proresdata.h"
+            "libavcodec/proresdec.c"
+            "libavcodec/proresdec.h"
+            "libavcodec/proresdsp.c"
+            "libavcodec/proresdsp.h"
+            "libavcodec/videotoolbox.c"
+            "libavcodec/videotoolbox_vp9.c"
+            "libavcodec/vt_internal.h"
+            "libavcodec/x86/proresdsp.asm"
+            "libavcodec/x86/proresdsp_init.c"
         )
         list(APPEND FFMPEG_ENABLE_DECODERS 
             "aac_at"
@@ -219,18 +234,12 @@ elseif(VCPKG_TARGET_IS_OSX)
     # The AVFoundation/CoreImage/VideoToolbox codec implementations are distributed by Apple to the end users.
     # The distribution requires patent licensing, and we can reasonably assume Apple fulfills this obligation.
     # This FFmpeg build only invokes the licensed codec implementations provided by Apple.
-    string(APPEND OPTIONS " --enable-audiotoolbox")
-    if(NOT ("fedora-ffmpeg-free-safe" IN_LIST FEATURES))
-        string(APPEND OPTIONS " --enable-avfoundation --enable-coreimage --enable-videotoolbox")
-    endif()
+    string(APPEND OPTIONS "  --enable-audiotoolbox --enable-avfoundation --enable-coreimage --enable-videotoolbox")
 elseif(VCPKG_TARGET_IS_IOS)
     # The AVFoundation/CoreImage/VideoToolbox codec implementations are distributed by Apple to the end users.
     # The distribution requires patent licensing, and we can reasonably assume Apple fulfills this obligation.
     # This FFmpeg build only invokes the licensed codec implementations provided by Apple.
-    string(APPEND OPTIONS " --enable-audiotoolbox")
-    if(NOT ("fedora-ffmpeg-free-safe" IN_LIST FEATURES))
-        string(APPEND OPTIONS " --enable-avfoundation --enable-coreimage --enable-videotoolbox")
-    endif()
+    string(APPEND OPTIONS "  --enable-audiotoolbox --enable-avfoundation --enable-coreimage --enable-videotoolbox")
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
     string(APPEND OPTIONS " --target-os=android --enable-jni --enable-mediacodec")
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "QNX")

--- a/overlay/ports/ffmpeg/vcpkg.json
+++ b/overlay/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
-  "version": "7.1",
-  "port-version": 4,
+  "version": "7.1",  
+  "port-version": 5,
   "description": [
     "A library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."


### PR DESCRIPTION
On macOS we can not link Qt6.10 QMultimedia because our FFmpeg code does not support the Apple frameworks `avfoundation` `coreimage` and `videotoolbox`.
```
undefined symbols for architecture arm64:
  "_av_map_videotoolbox_format_to_pixfmt", referenced from:
      QFFmpeg::isCVFormatSupported(unsigned int) in libQt6FFmpegMediaPluginImpl.a[3](qffmpeg.cpp.o)
      QFFmpeg::QAVFCamera::tryApplyFormatToCaptureSession(AVCaptureDevice*, AVCaptureDeviceFormat*, QCameraFormat const&) in libQt6FFmpegMediaPluginImpl.a[53](qavfcamera.mm.o)
      QFFmpeg::QAVFScreenCapture::initScreenCapture(QScreen*) in libQt6FFmpegMediaPluginImpl.a[59](qavfscreencapture.mm.o)
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```
The frameworks itself don't add a new license issue, because we use them already in Mixxx itself:
https://github.com/mixxxdj/mixxx/blob/e3e2f63a15024e59196a84667ed7918f036d6df1/CMakeLists.txt#L4413-L4428

But the other files I needed to add might, as these macOS specific files are not in the positive list from Fedora.

In general QtMultimedia adds a lot of dependencies and is needed for the controller screen support.

I'm not 100% sure that this fixes all build issues, as I've no access to macOS system.